### PR TITLE
Remove fresco install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ conda activate fresco
 ```
 Install the FrESCO library and dependencies
 ```shell
-pip install fresco .
+pip install .
 ```
 
 For further PyTorch instructions or more details for pytorch, head over to the [PyTorch docs](https://pytorch.org/docs/stable/index.html).


### PR DESCRIPTION
By including `fresco` in the pip install this results in the following non-related library being installed:

https://pypi.org/project/fresco/

... also, as a side note ... have you considered making your library pip installable (without needing to clone the repo?) ... and if you have, it might be worth changing the name of your package so as not to clash with pre-existing packages.